### PR TITLE
Harden ASA optimizer mutation boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ asa optimize --auto-approve
 2. Identifies **winners**: ≥2 installs, CPA ≤ $5
 3. Identifies **losers**: ≥$1 spend, 0 installs
 4. Promotes winners → exact match in target campaign + negative in Discovery
-5. Blocks losers → negative in all managed campaigns
+5. Blocks losers in Discovery by default (`--negative-scope managed` is explicit)
 
 ```bash
 # Customize thresholds

--- a/SKILL.md
+++ b/SKILL.md
@@ -218,6 +218,7 @@ asa config test
 | `asa optimize --min-impressions 100` | Min impressions to consider a term |
 | `asa optimize --exclude "term1,term2"` | Exclude specific terms from analysis |
 | `asa optimize --target brand` | Target campaign type (default: category) |
+| `asa optimize --negative-scope managed` | Explicitly block losers across all managed campaigns (default: Discovery only) |
 | `asa optimize --auto-approve` | Skip confirmation prompts |
 | `asa optimize --json` | Output results as JSON (implies --dry-run) |
 
@@ -298,7 +299,7 @@ The `asa optimize` command automatically:
 2. Identifies winners (≥2 installs, CPA ≤ $5)
 3. Identifies losers (≥$1 spend, 0 installs)
 4. Promotes winners to target campaign (adds as exact + negative in Discovery)
-5. Blocks losers across all managed campaigns
+5. Blocks losers in Discovery by default (`--negative-scope managed` is explicit)
 
 **Option 2: Manual**
 

--- a/asa_cli/commands/optimize.py
+++ b/asa_cli/commands/optimize.py
@@ -55,9 +55,16 @@ def get_campaigns_indexed(
 
     for c in campaigns:
         ctype = detect_campaign_type(c.get("name", ""), app_name=app_name)
-        if ctype:
-            by_type[ctype] = c
-            managed.append((c, ctype))
+        if not ctype:
+            continue
+        if ctype in by_type:
+            first_name = by_type[ctype].get("name", "?")
+            second_name = c.get("name", "?")
+            raise ValueError(
+                f"Multiple {ctype.value} campaigns matched: {first_name}, {second_name}"
+            )
+        by_type[ctype] = c
+        managed.append((c, ctype))
 
     return by_type, managed
 
@@ -203,12 +210,12 @@ def display_optimization_summary(
         table.add_column("Spend", justify="right")
         table.add_column("Impressions", justify="right")
 
-        for l in losers[:20]:
+        for loser in losers[:20]:
             table.add_row(
-                l["term"][:35],
-                str(l["installs"]),
-                format_currency(l["spend"]),
-                str(l["impressions"]),
+                loser["term"][:35],
+                str(loser["installs"]),
+                format_currency(loser["spend"]),
+                str(loser["impressions"]),
             )
 
         if len(losers) > 20:
@@ -255,39 +262,55 @@ def execute_promotions(
             match_type=MatchType.EXACT,
         )
 
-    if added and len(added) > 0:
+    added_terms = {
+        str(item.get("text", "")).strip().lower()
+        for item in added
+        if item.get("text")
+    }
+    all_duplicates = bool(errors) and all(
+        error.get("messageCode") == "DUPLICATE_KEYWORD" for error in errors
+    )
+
+    if added:
         console.print(f"[green]✓ Added {len(added)} keywords to {target_campaign.get('name')}[/green]")
-    elif errors:
-        all_duplicates = all(e.get("messageCode") == "DUPLICATE_KEYWORD" for e in errors)
-        if all_duplicates:
-            console.print(f"[dim]↳ {len(errors)} keywords already exist in {target_campaign.get('name')}[/dim]")
-            # Continue with negative keyword addition even if duplicates
-            added = keyword_list  # Treat as success for flow purposes
-        else:
-            console.print(f"[red]✗ Failed: {errors[0].get('message', 'Unknown error')}[/red]")
-            return 0, len(winners)
+    elif all_duplicates:
+        console.print(
+            f"[dim]↳ {len(errors)} keywords already exist in "
+            f"{target_campaign.get('name')}[/dim]"
+        )
     else:
-        console.print(f"[red]✗ Failed to add keywords to target campaign[/red]")
+        message = errors[0].get("message", "Unknown error") if errors else "Unknown error"
+        console.print(f"[red]✗ Failed: {message}[/red]")
+        return 0, len(winners)
+
+    safe_terms = (
+        keyword_list
+        if all_duplicates
+        else [term for term in keyword_list if term.strip().lower() in added_terms]
+    )
+    if not safe_terms:
+        console.print("[yellow]No confirmed promotions to negate in Discovery.[/yellow]")
         return 0, len(winners)
 
     with console.status("[bold blue]Adding negatives to Discovery..."):
-        neg_added, neg_errors = client.add_negative_keywords(discovery_id, keyword_list)
+        neg_added, neg_errors = client.add_negative_keywords(discovery_id, safe_terms)
 
     if neg_added and len(neg_added) > 0:
         console.print(f"[green]✓ Added {len(neg_added)} negatives to Discovery[/green]")
     elif neg_errors:
         # Check if all errors are duplicates (which is fine)
-        all_duplicates = all(e.get("messageCode") == "DUPLICATE_KEYWORD" for e in neg_errors)
-        if all_duplicates:
+        negatives_are_duplicates = all(
+            error.get("messageCode") == "DUPLICATE_KEYWORD" for error in neg_errors
+        )
+        if negatives_are_duplicates:
             console.print(f"[dim]↳ {len(neg_errors)} negatives already exist in Discovery[/dim]")
         else:
             console.print(f"[yellow]⚠ Could not add negatives to Discovery: {neg_errors[0].get('message', 'Unknown error')}[/yellow]")
     else:
-        console.print(f"[yellow]⚠ Could not add negatives to Discovery[/yellow]")
+        console.print("[yellow]⚠ Could not add negatives to Discovery[/yellow]")
 
-    # Return count based on what was actually promoted
-    promoted_count = len(added) if isinstance(added, list) else len(keyword_list)
-    return promoted_count, 0
+    promoted_count = len(safe_terms)
+    return promoted_count, len(winners) - promoted_count
 
 
 def execute_negatives(
@@ -302,11 +325,11 @@ def execute_negatives(
     if not losers:
         return 0, 0
 
-    keyword_list = [l["term"] for l in losers]
+    keyword_list = [loser["term"] for loser in losers]
     success_count = 0
     failure_count = 0
 
-    for campaign, ctype in managed_campaigns:
+    for campaign, _campaign_type in managed_campaigns:
         cid = campaign.get("id")
         cname = campaign.get("name")
 
@@ -361,6 +384,11 @@ def optimize_cmd(
         "--target",
         "-t",
         help="Target campaign for promotions: brand, category, competitor",
+    ),
+    negative_scope: str = typer.Option(
+        "discovery",
+        "--negative-scope",
+        help="Where to add loser negatives: discovery or managed",
     ),
     output_json: bool = typer.Option(
         False, "--json", help="Output results as JSON (implies --dry-run)"
@@ -418,16 +446,36 @@ def optimize_cmd(
 
     target_type = target_type_map[target.lower()]
 
+    negative_scope = negative_scope.lower()
+    if negative_scope not in {"discovery", "managed"}:
+        if output_json:
+            print(json.dumps({"error": f"Invalid negative scope: {negative_scope}"}))
+        else:
+            console.print("[red]Invalid negative scope. Use discovery or managed.[/red]")
+        raise typer.Exit(1)
+
     client = SearchAdsClient(credentials)
     app_name = _resolve_app_name()
 
     if not output_json:
         with console.status("[bold blue]Finding campaigns..."):
-            campaigns_by_type, managed_campaigns = get_campaigns_indexed(client, app_name=app_name)
+            try:
+                campaigns_by_type, managed_campaigns = get_campaigns_indexed(
+                    client, app_name=app_name
+                )
+            except ValueError as error:
+                console.print(f"[red]{error}[/red]")
+                raise typer.Exit(1) from error
             discovery_campaign = campaigns_by_type.get(CampaignType.DISCOVERY)
             target_campaign = campaigns_by_type.get(target_type)
     else:
-        campaigns_by_type, managed_campaigns = get_campaigns_indexed(client, app_name=app_name)
+        try:
+            campaigns_by_type, managed_campaigns = get_campaigns_indexed(
+                client, app_name=app_name
+            )
+        except ValueError as error:
+            print(json.dumps({"error": str(error)}))
+            raise typer.Exit(1) from error
         discovery_campaign = campaigns_by_type.get(CampaignType.DISCOVERY)
         target_campaign = campaigns_by_type.get(target_type)
 
@@ -497,6 +545,7 @@ def optimize_cmd(
                 "min_impressions": min_impressions,
                 "exclude_terms": exclude_list,
                 "target_campaign": target_type.value,
+                "negative_scope": negative_scope,
             },
             "campaigns": {
                 "discovery": {
@@ -526,12 +575,12 @@ def optimize_cmd(
             ],
             "losers": [
                 {
-                    "term": l["term"],
-                    "spend": l["spend"],
-                    "impressions": l["impressions"],
-                    "taps": l["taps"],
+                    "term": loser["term"],
+                    "spend": loser["spend"],
+                    "impressions": loser["impressions"],
+                    "taps": loser["taps"],
                 }
-                for l in losers
+                for loser in losers
             ],
         }
         print(json.dumps(output_data, indent=2))
@@ -577,7 +626,12 @@ def optimize_cmd(
         )
 
     if losers:
-        neg_success, neg_failed = execute_negatives(client, losers, managed_campaigns)
+        negative_campaigns = (
+            [(discovery_campaign, CampaignType.DISCOVERY)]
+            if negative_scope == "discovery"
+            else managed_campaigns
+        )
+        neg_success, neg_failed = execute_negatives(client, losers, negative_campaigns)
 
     console.print("\n[bold green]Optimization complete![/bold green]")
 
@@ -592,4 +646,3 @@ def optimize_cmd(
 
     if failed_promo > 0 or neg_failed > 0:
         console.print(f"[yellow]Failures: {failed_promo} promotions, {neg_failed} campaign blocks[/yellow]")
-

--- a/tests/test_optimize_safety.py
+++ b/tests/test_optimize_safety.py
@@ -1,0 +1,158 @@
+"""Command-level safety tests for campaign optimization."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from asa_cli.commands import optimize
+from asa_cli.config import CampaignType
+
+runner = CliRunner()
+
+
+def campaign(campaign_id: int, name: str) -> dict:
+    return {"id": campaign_id, "name": name, "status": "RUNNING"}
+
+
+def report_row(term: str, installs: int, spend: float) -> dict:
+    return {
+        "metadata": {"searchTermText": term, "searchTermSource": "BROAD"},
+        "total": {
+            "impressions": 100,
+            "taps": 10,
+            "totalInstalls": installs,
+            "localSpend": {"amount": str(spend)},
+        },
+    }
+
+
+class FakeClient:
+    """Read fixture that records attempted campaign mutations."""
+
+    def __init__(self, _credentials):
+        self.mutations: list[tuple[str, int, list[str]]] = []
+        self.rows = [report_row("winner", 3, 1.20), report_row("waste", 0, 2.00)]
+
+    def get_campaigns(self):
+        return [
+            campaign(1, "StitchIt - Brand"),
+            campaign(2, "StitchIt - Category"),
+            campaign(3, "StitchIt - Competitor"),
+            campaign(4, "StitchIt - Discovery"),
+        ]
+
+    def get_search_terms_report(self, _campaign_id, _start, _end):
+        return self.rows
+
+    def get_ad_groups(self, campaign_id):
+        return [{"id": campaign_id * 10, "name": "Exact"}]
+
+    def add_keywords(self, campaign_id, ad_group_id, keywords, match_type):
+        del ad_group_id, match_type
+        self.mutations.append(("keywords", campaign_id, keywords))
+        return ([{"id": 10, "text": term} for term in keywords], [])
+
+    def add_negative_keywords(self, campaign_id, keywords):
+        self.mutations.append(("negatives", campaign_id, keywords))
+        return ([{"id": 20, "text": term} for term in keywords], [])
+
+
+def invoke_with_fake_client(args: list[str], *, rows=None):
+    fake = FakeClient(object())
+    if rows is not None:
+        fake.rows = rows
+    with (
+        patch.object(optimize, "load_credentials", return_value=object()),
+        patch.object(optimize, "SearchAdsClient", return_value=fake),
+        patch.object(optimize, "_resolve_app_name", return_value="StitchIt"),
+    ):
+        result = runner.invoke(optimize.app, args)
+    return result, fake
+
+
+def test_duplicate_campaign_types_fail_closed():
+    client = FakeClient(object())
+    client.get_campaigns = lambda: [
+        campaign(1, "StitchIt - Category"),
+        campaign(2, "StitchIt - Category v2"),
+    ]
+
+    with pytest.raises(ValueError, match="Multiple category campaigns matched"):
+        optimize.get_campaigns_indexed(client, app_name="StitchIt")
+
+
+def test_partial_promotion_only_negates_confirmed_added_terms():
+    class PartialClient(FakeClient):
+        def add_keywords(self, campaign_id, ad_group_id, keywords, match_type):
+            del campaign_id, ad_group_id, keywords, match_type
+            return ([{"id": 10, "text": "safe term"}], [{"messageCode": "INVALID"}])
+
+    client = PartialClient(object())
+    promoted, failed = optimize.execute_promotions(
+        client,
+        [{"term": "safe term"}, {"term": "failed term"}],
+        campaign(2, "StitchIt - Category"),
+        campaign(4, "StitchIt - Discovery"),
+    )
+
+    assert client.mutations == [("negatives", 4, ["safe term"])]
+    assert (promoted, failed) == (1, 1)
+
+
+def test_dry_run_never_calls_mutation_methods():
+    result, fake = invoke_with_fake_client(["--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert fake.mutations == []
+
+
+def test_json_never_calls_mutation_methods_and_is_valid_json():
+    result, fake = invoke_with_fake_client(["--json"])
+
+    assert result.exit_code == 0, result.output
+    assert fake.mutations == []
+    assert json.loads(result.output)["settings"]["negative_scope"] == "discovery"
+
+
+def test_default_negative_scope_only_mutates_discovery():
+    result, fake = invoke_with_fake_client(
+        ["--auto-approve"],
+        rows=[report_row("waste", 0, 2.00)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake.mutations == [("negatives", 4, ["waste"])]
+
+
+def test_managed_negative_scope_is_explicit():
+    result, fake = invoke_with_fake_client(
+        ["--auto-approve", "--negative-scope", "managed"],
+        rows=[report_row("waste", 0, 2.00)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [mutation[1] for mutation in fake.mutations] == [1, 2, 3, 4]
+
+
+def test_duplicate_campaign_error_prevents_command_mutations():
+    fake = FakeClient(object())
+    fake.get_campaigns = lambda: [
+        campaign(2, "StitchIt - Category"),
+        campaign(5, "StitchIt - Category v2"),
+    ]
+    with (
+        patch.object(optimize, "load_credentials", return_value=object()),
+        patch.object(optimize, "SearchAdsClient", return_value=fake),
+        patch.object(optimize, "_resolve_app_name", return_value="StitchIt"),
+    ):
+        result = runner.invoke(optimize.app, ["--auto-approve"])
+
+    assert result.exit_code == 1
+    assert "Multiple category campaigns matched" in result.output
+    assert fake.mutations == []
+
+
+def test_discovery_scope_uses_campaign_type_contract():
+    assert CampaignType.DISCOVERY.value == "discovery"


### PR DESCRIPTION
## Summary
- fail closed when campaign-name detection finds multiple campaigns of one managed type
- default loser negatives to Discovery; require `--negative-scope managed` for cross-campaign blocking
- on partial promotion success, negate only terms confirmed added (or a fully duplicate batch)
- add command-level mutation-spy tests proving `--dry-run` and `--json` cannot write

## Deliberately deferred
- June auto-routing and keyword-inventory architecture
- exact-inventory routing heuristics
- keyword triage apply support
- broad automatic optimizer expansion

Those remain outside this conservative tranche. No generated `outputs/` artifacts are included and no live Apple Search Ads mutations were run.

## Verification
- `uv run pytest -q` — 255 passed
- `uv run ruff check asa_cli/commands/optimize.py tests/test_optimize_safety.py` — passed
- `git diff --check` — passed

Tracks `roadmap-tt3e`; test coverage also supports `roadmap-quo`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--negative-scope managed` to apply losing-keyword negatives across all managed campaigns.
  * Loser blocking now defaults to the Discovery campaign.
  * JSON output now reports the selected negative scope.

* **Bug Fixes**
  * Improved campaign matching and error handling to prevent unsafe changes.
  * Promotions now report accurate results and only confirmed keywords are negated.
  * Dry runs and JSON output no longer perform campaign mutations.

* **Documentation**
  * Updated workflow documentation to explain the default and managed negative scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->