### PR TITLE
Rename the project to Apple Ads CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Contributions are welcome, especially reproducible endpoint fixes, official-SDK 
 ## Development setup
 
 ```bash
-git clone https://github.com/cameronehrlich/apple-search-ads-cli.git
-cd apple-search-ads-cli
+git clone https://github.com/cameronehrlich/apple-ads-cli.git
+cd apple-ads-cli
 uv sync --all-extras
 uv run pytest -q
 ```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 An independent, scriptable command-line interface for Apple Ads. It wraps every public operation in Apple’s official Python SDK, preserves the previous Campaign Management API v5 implementation, and adds safety-focused workflows for real advertising accounts.
 
+The project follows Apple’s current Apple Ads name. The established `asa` executable, `asa-cli` Python distribution, and `asa_cli` import package remain unchanged for compatibility. The bundled Codex skill is invoked as `$apple-ads-cli`.
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Apple Ads Platform SDK 1.109.0](https://img.shields.io/badge/Apple%20Ads%20Platform%20SDK-1.109.0-black.svg)](https://github.com/apple/apple-ads-platform-api-python/releases/tag/v1.109.0)
-[![CI](https://github.com/cameronehrlich/apple-search-ads-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/cameronehrlich/apple-search-ads-cli/actions/workflows/ci.yml)
+[![CI](https://github.com/cameronehrlich/apple-ads-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/cameronehrlich/apple-ads-cli/actions/workflows/ci.yml)
 
 ## Why this CLI
 
@@ -22,8 +24,8 @@ Coverage is checked mechanically against a pinned SDK manifest. That proves loca
 Python 3.12 or newer and [uv](https://docs.astral.sh/uv/) are required for the recommended development install.
 
 ```bash
-git clone https://github.com/cameronehrlich/apple-search-ads-cli.git
-cd apple-search-ads-cli
+git clone https://github.com/cameronehrlich/apple-ads-cli.git
+cd apple-ads-cli
 
 uv sync --all-extras
 uv run asa version
@@ -40,7 +42,7 @@ asa version
 Automation should install the exact 1.1.1 tag rather than following `main`:
 
 ```bash
-uv tool install 'git+https://github.com/cameronehrlich/apple-search-ads-cli.git@1.1.1'
+uv tool install 'git+https://github.com/cameronehrlich/apple-ads-cli.git@1.1.1'
 ```
 
 ## Configure
@@ -195,7 +197,7 @@ After every confirmed mutation, read the resource back and compare each intended
 
 The complete inventory and all 35 request-model schemas are in the [generated command index](references/command-index.md).
 
-## Opinionated workflows
+## Optional higher-level workflows
 
 Only behavior that remains useful above the official SDK is ported into `asa workflows`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,9 +64,9 @@ If a run fails after creating its draft, inspect that draft and the workflow log
 ## After publishing
 
 ```bash
-gh release view 1.1.1 --repo cameronehrlich/apple-search-ads-cli
+gh release view 1.1.1 --repo cameronehrlich/apple-ads-cli
 uv tool install --force \
-  'git+https://github.com/cameronehrlich/apple-search-ads-cli.git@1.1.1'
+  'git+https://github.com/cameronehrlich/apple-ads-cli.git@1.1.1'
 asa version
 asa config test
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: apple-search-ads-cli
-description: Use the ASA CLI for Apple Ads Platform API v1 and legacy Apple Search Ads API v5. Trigger when Codex needs exact CLI syntax for campaigns, ad groups, ads, creatives, keywords, negatives, budgets, accounts, apps, Apple Maps brands or locations, reports, impression share, search-term popularity, recommendations, suggestions, change history, v5 migration or fallback, or this repository's strategy audit, manual search-results, Maximize Conversions, campaign-structure, and optimization workflows. Also use when mapping an Apple SDK endpoint to its CLI wrapper or safely executing Apple Ads mutations.
+name: apple-ads-cli
+description: Use the ASA CLI for Apple Ads Platform API v1 and legacy Campaign Management API v5. Trigger when Codex needs exact CLI syntax for campaigns, ad groups, ads, creatives, keywords, negatives, budgets, accounts, apps, Apple Maps brands or locations, reports, impression share, search-term popularity, recommendations, suggestions, change history, v5 migration or fallback, or this repository's strategy audit, manual search-results, Maximize Conversions, campaign-structure, and optimization workflows. Also use when mapping an Apple SDK endpoint to its CLI wrapper or safely executing Apple Ads mutations.
 ---
 
 # Apple Ads CLI

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Apple Ads CLI"
   short_description: "Run every Apple Ads API command safely"
-  default_prompt: "Use $apple-search-ads-cli to select and safely run the exact Apple Ads command for this request."
+  default_prompt: "Use $apple-ads-cli to select and safely run the exact Apple Ads command for this request."
 policy:
   allow_implicit_invocation: true

--- a/asa_cli/__init__.py
+++ b/asa_cli/__init__.py
@@ -1,3 +1,3 @@
-"""Apple Search Ads CLI - Manage campaigns, keywords, and reporting."""
+"""Apple Ads CLI - Manage campaigns, keywords, insights, and reporting."""
 
 __version__ = "1.1.1"

--- a/asa_cli/api.py
+++ b/asa_cli/api.py
@@ -1,4 +1,4 @@
-"""Backward-compatible imports for the Apple Search Ads v5 client.
+"""Backward-compatible imports for the Apple Ads Campaign Management API v5 client.
 
 New code should import from :mod:`asa_cli.v5.api`.
 """

--- a/asa_cli/commands/campaigns.py
+++ b/asa_cli/commands/campaigns.py
@@ -594,7 +594,7 @@ def clone_campaign(
 ):
     """Duplicate a campaign (with ad groups, keywords, and negatives).
 
-    Apple Search Ads has no native campaign-duplication endpoint, so
+    Apple Ads Campaign Management API v5 has no native campaign-duplication endpoint, so
     this reads the source and re-creates it. Useful to escape a stuck
     TOTAL_BUDGET_EXHAUSTED state after clearing a lifetime budget —
     Apple caches that flag even after the cap is gone, and only a fresh

--- a/asa_cli/commands/config.py
+++ b/asa_cli/commands/config.py
@@ -78,10 +78,11 @@ def setup_config(
 
     console.print("\n[bold green]Configuration complete![/bold green]")
     console.print("\nNext steps:")
-    console.print("  1. Run [cyan]asa v5 campaigns audit[/cyan] to check existing campaigns")
+    console.print("  1. Run [cyan]asa --help[/cyan] to explore Platform API v1 resources")
     console.print(
-        "  2. Run [cyan]asa v5 campaigns setup[/cyan] to create the 4-campaign structure"
+        "  2. Run [cyan]asa workflows campaigns audit --strategy auto[/cyan] for a safe audit"
     )
+    console.print("  3. Run [cyan]asa v5 --help[/cyan] for the legacy compatibility surface")
 
 
 @app.command("show")
@@ -151,7 +152,7 @@ def test_connection():
 
         client = SearchAdsClient(credentials)
 
-        with console.status("[bold blue]Connecting to Apple Search Ads API..."):
+        with console.status("[bold blue]Connecting to Apple Ads API..."):
             campaigns = client.get_campaigns()
 
         console.print("[green]Connection successful![/green]")
@@ -160,7 +161,7 @@ def test_connection():
 
     except ImportError as e:
         console.print(f"[red]Missing dependency: {e}[/red]")
-        console.print("  Run: pip install -e . (from the apple-search-ads directory)")
+        console.print("  Run: pip install -e . (from the apple-ads-cli directory)")
         raise typer.Exit(1) from e
     except Exception as e:
         console.print(f"[red]Connection failed: {e}[/red]")

--- a/asa_cli/config.py
+++ b/asa_cli/config.py
@@ -1,4 +1,4 @@
-"""Configuration management for Apple Search Ads CLI."""
+"""Configuration management for Apple Ads CLI."""
 
 import json
 import os
@@ -113,7 +113,7 @@ CAMPAIGN_TYPE_NAMES = {
 
 
 class Credentials(BaseModel):
-    """API credentials for Apple Search Ads."""
+    """API credentials for Apple Ads."""
 
     org_id: Optional[int] = Field(
         None,
@@ -372,7 +372,7 @@ def parse_campaign_name(name: str, app_name: Optional[str] = None) -> Optional[t
 
 def prompt_for_credentials() -> Credentials:
     """Interactively prompt for API credentials."""
-    console.print("\n[bold]Apple Search Ads API Credentials Setup[/bold]\n")
+    console.print("\n[bold]Apple Ads API Credentials Setup[/bold]\n")
     console.print("You'll need to create API credentials in Apple Ads dashboard first.")
     console.print("See: https://ads.apple.com/help/campaigns/0022-use-the-campaign-management-api\n")
 

--- a/asa_cli/main.py
+++ b/asa_cli/main.py
@@ -17,7 +17,7 @@ from .workflows.cli import app as workflows_app
 
 app = typer.Typer(
     name="asa",
-    help="Apple Ads Platform API v1, legacy v5, and opinionated workflows.",
+    help="Apple Ads Platform API v1, legacy v5, and optional higher-level workflows.",
     no_args_is_help=True,
     rich_markup_mode="rich",
 )
@@ -31,7 +31,7 @@ app.add_typer(v5_app, name="v5", help="Legacy Campaign Management API v5 command
 app.add_typer(
     workflows_app,
     name="workflows",
-    help="Opinionated workflows built on Platform API v1",
+    help="Safety-focused workflows built on Platform API v1",
 )
 app.add_typer(
     platform_app,
@@ -69,7 +69,7 @@ def help_command() -> None:
     [cyan]asa campaigns create --file campaign.json[/cyan]
     [cyan]asa campaigns create --file campaign.json --confirm[/cyan]
 
-[bold]Opinionated workflows[/bold]
+[bold]Optional higher-level workflows[/bold]
     [cyan]asa workflows campaigns audit[/cyan]
     [cyan]asa workflows campaigns plan-four-structure[/cyan]
     [cyan]asa workflows campaigns plan-maximize-conversions[/cyan]

--- a/asa_cli/platform/manifest/apple_ads_platform_manifest.schema.json
+++ b/asa_cli/platform/manifest/apple_ads_platform_manifest.schema.json
@@ -325,7 +325,7 @@
       "type": "object"
     }
   },
-  "$id": "https://github.com/cameronehrlich/apple-search-ads-cli/schemas/apple-ads-platform-manifest-v2.json",
+  "$id": "https://github.com/cameronehrlich/apple-ads-cli/schemas/apple-ads-platform-manifest-v2.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {

--- a/asa_cli/platform/manifest_discovery.py
+++ b/asa_cli/platform/manifest_discovery.py
@@ -538,7 +538,7 @@ def discover_manifest() -> dict[str, Any]:
 
 MANIFEST_SCHEMA: dict[str, Any] = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/cameronehrlich/apple-search-ads-cli/schemas/apple-ads-platform-manifest-v2.json",
+    "$id": "https://github.com/cameronehrlich/apple-ads-cli/schemas/apple-ads-platform-manifest-v2.json",
     "title": "Apple Ads Platform SDK manifest",
     "type": "object",
     "additionalProperties": False,

--- a/asa_cli/v5/__init__.py
+++ b/asa_cli/v5/__init__.py
@@ -1,4 +1,4 @@
-"""Apple Search Ads Campaign Management API v5 compatibility package."""
+"""Apple Ads Campaign Management API v5 compatibility package."""
 
 from .api import (
     API_BASE_URL,

--- a/asa_cli/v5/api.py
+++ b/asa_cli/v5/api.py
@@ -1,4 +1,4 @@
-"""Direct API client for Apple Search Ads using JWT OAuth authentication."""
+"""Direct client for Apple Ads Campaign Management API v5 using JWT OAuth."""
 
 import time
 from datetime import datetime, timedelta
@@ -23,7 +23,7 @@ class SearchAdsAPIError(RuntimeError):
 
 
 class SearchAdsClient:
-    """Direct Apple Search Ads API client with JWT authentication."""
+    """Direct Apple Ads Campaign Management API v5 client with JWT authentication."""
 
     def __init__(self, credentials: Optional[Credentials] = None, app_config: Optional[AppConfig] = None):
         """Initialize the API client.
@@ -188,7 +188,7 @@ class SearchAdsClient:
     ) -> list[dict[str, Any]]:
         """Fetch all results from a paginated endpoint.
 
-        Apple Search Ads API defaults to 20 items per page. This method fetches
+        Apple Ads Campaign Management API v5 defaults to 20 items per page. This method fetches
         all pages and returns the combined results.
 
         Args:

--- a/asa_cli/v5/cli.py
+++ b/asa_cli/v5/cli.py
@@ -1,4 +1,4 @@
-"""Typer command tree for the Apple Search Ads v5 implementation."""
+"""Typer command tree for the Apple Ads Campaign Management API v5 implementation."""
 
 from typing import Final
 
@@ -44,7 +44,7 @@ def register_v5_commands(parent: typer.Typer, *, deprecated: bool = False) -> No
 
 app = typer.Typer(
     name="v5",
-    help="Apple Search Ads Campaign Management API v5 commands.",
+    help="Legacy Apple Ads Campaign Management API v5 commands.",
     no_args_is_help=True,
     rich_markup_mode="rich",
 )

--- a/docs/API-COMPLETION-PLAN.md
+++ b/docs/API-COMPLETION-PLAN.md
@@ -1,6 +1,6 @@
 # ASA CLI — API Completion Plan
 
-Complete coverage of Apple Search Ads Campaign Management API v5.
+Complete coverage of the legacy Apple Ads Campaign Management API v5.
 
 ## Current State
 
@@ -175,10 +175,10 @@ Every API method gets:
 ### Running Tests
 ```bash
 # Unit tests only (fast, no API calls)
-cd ~/apple-search-ads-cli && uv run pytest tests/ -v
+cd ~/apple-ads-cli && uv run pytest tests/ -v
 
 # Including integration tests (requires API credentials)
-cd ~/apple-search-ads-cli && uv run pytest tests/ -v -m integration
+cd ~/apple-ads-cli && uv run pytest tests/ -v -m integration
 ```
 
 ---
@@ -202,5 +202,5 @@ cd ~/apple-search-ads-cli && uv run pytest tests/ -v -m integration
 ## Notes
 
 - The sosumi research agent is currently pulling the complete API v5 endpoint reference from Apple's docs. Once that completes, this plan should be updated with any endpoints we missed.
-- All changes should be committed to `~/apple-search-ads-cli` main branch per Cameron's request.
+- All changes should be committed to `~/apple-ads-cli` main branch per Cameron's request.
 - The `research` command added during this session is a stub — update it once we confirm whether keyword recommendation endpoints exist in v5.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 authors = [
     {name = "Cameron Ehrlich", email = "cameron@ehrlich.io"}
 ]
-keywords = ["apple", "search-ads", "asa", "cli", "marketing", "app-store", "ios"]
+keywords = ["apple", "apple-ads", "search-ads", "asa", "cli", "marketing", "app-store", "ios"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
@@ -47,10 +47,10 @@ dev = [
 asa = "asa_cli.main:app"
 
 [project.urls]
-"Homepage" = "https://github.com/cameronehrlich/apple-search-ads-cli"
-"Documentation" = "https://github.com/cameronehrlich/apple-search-ads-cli#readme"
-"Issues" = "https://github.com/cameronehrlich/apple-search-ads-cli/issues"
-"Releases" = "https://github.com/cameronehrlich/apple-search-ads-cli/releases"
+"Homepage" = "https://github.com/cameronehrlich/apple-ads-cli"
+"Documentation" = "https://github.com/cameronehrlich/apple-ads-cli#readme"
+"Issues" = "https://github.com/cameronehrlich/apple-ads-cli/issues"
+"Releases" = "https://github.com/cameronehrlich/apple-ads-cli/releases"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/references/v5-fallback.md
+++ b/references/v5-fallback.md
@@ -404,7 +404,7 @@ Audit current campaign structure against Apple's recommendations.
 
 Duplicate a campaign (with ad groups, keywords, and negatives).
 
-Apple Search Ads has no native campaign-duplication endpoint, so
+Apple Ads Campaign Management API v5 has no native campaign-duplication endpoint, so
 this reads the source and re-creates it. Useful to escape a stuck
 TOTAL_BUDGET_EXHAUSTED state after clearing a lifetime budget —
 Apple caches that flag even after the cap is gone, and only a fresh

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SEMVER = re.compile(r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)")
+CANONICAL_REPOSITORY = "https://github.com/cameronehrlich/apple-ads-cli"
 
 
 def package_version() -> str:
@@ -66,6 +67,17 @@ def validate(expected_version: str | None = None) -> tuple[str, str]:
     readme = (ROOT / "README.md").read_text()
     if f"Apple Ads Platform SDK {sdk_version}" not in readme:
         raise ValueError("README SDK badge or version statement is stale")
+
+    expected_urls = {
+        "Homepage": CANONICAL_REPOSITORY,
+        "Documentation": f"{CANONICAL_REPOSITORY}#readme",
+        "Issues": f"{CANONICAL_REPOSITORY}/issues",
+        "Releases": f"{CANONICAL_REPOSITORY}/releases",
+    }
+    if project.get("urls") != expected_urls:
+        raise ValueError("project URLs do not match the canonical Apple Ads CLI repository")
+    if CANONICAL_REPOSITORY not in readme:
+        raise ValueError("README does not reference the canonical Apple Ads CLI repository")
 
     return project_version, sdk_version
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 
 from asa_cli import __version__
 from asa_cli.main import app
-from scripts.check_release import validate
+from scripts.check_release import CANONICAL_REPOSITORY, validate
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -38,3 +38,21 @@ def test_cli_framework_version_is_pinned_to_the_verified_command_tree():
     assert "click==8.3.1" in project["dependencies"]
     assert version("typer") == "0.24.0"
     assert version("click") == "8.3.1"
+
+
+def test_public_metadata_uses_the_canonical_repository_without_renaming_the_cli():
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+
+    assert project["name"] == "asa-cli"
+    assert project["scripts"] == {"asa": "asa_cli.main:app"}
+    assert project["urls"] == {
+        "Homepage": CANONICAL_REPOSITORY,
+        "Documentation": f"{CANONICAL_REPOSITORY}#readme",
+        "Issues": f"{CANONICAL_REPOSITORY}/issues",
+        "Releases": f"{CANONICAL_REPOSITORY}/releases",
+    }
+
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    agent_metadata = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+    assert "name: apple-ads-cli\n" in skill
+    assert "$apple-ads-cli" in agent_metadata

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 
 from asa_cli import __version__
 from asa_cli.main import app
-from scripts.check_release import CANONICAL_REPOSITORY, validate
+from scripts.check_release import validate
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -42,14 +42,15 @@ def test_cli_framework_version_is_pinned_to_the_verified_command_tree():
 
 def test_public_metadata_uses_the_canonical_repository_without_renaming_the_cli():
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    canonical_repository = "https://github.com/cameronehrlich/apple-ads-cli"
 
     assert project["name"] == "asa-cli"
     assert project["scripts"] == {"asa": "asa_cli.main:app"}
     assert project["urls"] == {
-        "Homepage": CANONICAL_REPOSITORY,
-        "Documentation": f"{CANONICAL_REPOSITORY}#readme",
-        "Issues": f"{CANONICAL_REPOSITORY}/issues",
-        "Releases": f"{CANONICAL_REPOSITORY}/releases",
+        "Homepage": canonical_repository,
+        "Documentation": f"{canonical_repository}#readme",
+        "Issues": f"{canonical_repository}/issues",
+        "Releases": f"{canonical_repository}/releases",
     }
 
     skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- adopts **Apple Ads CLI** as the public project name and `apple-ads-cli` as the canonical repository slug
- updates README, contributor, release, package, schema, and generated skill references to the new canonical URL
- preserves the `asa` executable, `asa-cli` distribution, and `asa_cli` import package
- renames the bundled skill to `$apple-ads-cli`
- presents Platform API v1 first, legacy Campaign Management API v5 explicitly, and safety-focused workflows as optional higher-level behavior
- adds release-metadata regression coverage for the canonical repository and stable CLI entry point

## Why

Apple now uses the Apple Ads brand. The previous repository description centered the project on one four-campaign workflow and did not describe complete Platform API v1 coverage or preserved v5 compatibility.

## Validation

- `uv run ruff check .`
- `uv run pytest -q` — 408 passed
- Platform manifest drift check
- generated skill-reference drift check — 20 files current
- Codex skill validation
- release metadata check for CLI 1.1.1 / SDK 1.109.0
- wheel and source distribution build; wheel retains `asa = asa_cli.main:app` and publishes the new project URLs
- untracked `graphify-out/` and `outputs/` were preserved and excluded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project naming and repository links to Apple Ads CLI across setup, release, API, workflow, and campaign guidance.
  * Clarified references to the Platform API v1 and Campaign Management API v5.
  * Refined CLI help text, credential setup messaging, and manifest documentation.

* **Chores**
  * Updated package metadata, skill configuration, agent prompts, and schema identifiers.
  * Preserved existing package, executable, and import names for compatibility.

* **Tests**
  * Added release checks for canonical repository links and required package and metadata identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->