### PR TITLE
Release Apple Ads CLI 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ python3.12 -m pip install -e '.[dev]'
 asa version
 ```
 
-Automation should install the exact 1.1.1 tag rather than following `main`:
+Automation should install the exact 1.1.2 tag rather than following `main`:
 
 ```bash
-uv tool install 'git+https://github.com/cameronehrlich/apple-ads-cli.git@1.1.1'
+uv tool install 'git+https://github.com/cameronehrlich/apple-ads-cli.git@1.1.2'
 ```
 
 ## Configure
@@ -296,10 +296,11 @@ The CLI uses semantic versions and bare tags such as `1.1.0`. GitHub Releases co
 | `1.0.0` | Immutable legacy Campaign Management API v5 baseline from the former `main` code line |
 | `1.1.0` | Backward-compatible Platform API v1 default, explicit `asa v5` fallback, generated skill, and strategy-aware workflows |
 | `1.1.1` | Response-model drift inventory and fail-closed validation hardening for confirmed live SDK mismatches |
+| `1.1.2` | Apple Ads CLI repository branding and organization-currency-safe legacy v5 campaign, ad group, keyword, and budget writes |
 
 CLI and SDK versions are intentionally independent:
 
-- `asa 1.1.1` describes this project’s command and behavior contract.
+- `asa 1.1.2` describes this project’s command and behavior contract.
 - `apple-ads-platform 1.109.0` identifies the exact Apple SDK contract it wraps.
 
 Automation should pin a CLI release, run `asa config test`, and perform a safe read before depending on an endpoint. See [RELEASING.md](RELEASING.md) for the release process and versioning policy.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,7 +29,7 @@ uv run ruff check .
 uv run pytest -q
 uv run python -m asa_cli.platform.generate_manifest --check
 uv run python scripts/generate_skill_references.py --check
-uv run python scripts/check_release.py --version 1.1.1
+uv run python scripts/check_release.py --version 1.1.2
 uv build
 git diff --check
 ```
@@ -42,8 +42,8 @@ git diff --check
 Create an annotated tag on the accepted `main` commit and push only that tag:
 
 ```bash
-git tag -a 1.1.1 -m 'Apple Ads CLI 1.1.1'
-git push origin 1.1.1
+git tag -a 1.1.2 -m 'Apple Ads CLI 1.1.2'
+git push origin 1.1.2
 ```
 
 Tag pushes matching `X.Y.Z` trigger `.github/workflows/release.yml`. The workflow:
@@ -64,9 +64,9 @@ If a run fails after creating its draft, inspect that draft and the workflow log
 ## After publishing
 
 ```bash
-gh release view 1.1.1 --repo cameronehrlich/apple-ads-cli
+gh release view 1.1.2 --repo cameronehrlich/apple-ads-cli
 uv tool install --force \
-  'git+https://github.com/cameronehrlich/apple-ads-cli.git@1.1.1'
+  'git+https://github.com/cameronehrlich/apple-ads-cli.git@1.1.2'
 asa version
 asa config test
 ```

--- a/asa_cli/__init__.py
+++ b/asa_cli/__init__.py
@@ -1,3 +1,3 @@
 """Apple Ads CLI - Manage campaigns, keywords, insights, and reporting."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asa-cli"
-version = "1.1.1"
+version = "1.1.2"
 description = "Complete CLI wrapper for Apple's official Apple Ads Platform SDK, with safe mutations and v5 compatibility"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -18,7 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_release_metadata_is_internally_consistent():
     cli_version, sdk_version = validate(__version__)
 
-    assert cli_version == "1.1.1"
+    assert cli_version == "1.1.2"
     assert sdk_version == "1.109.0"
 
 
@@ -27,7 +27,7 @@ def test_version_reports_cli_sdk_and_python_versions():
 
     assert result.exit_code == 0
     assert unstyle(result.stdout) == (
-        f"asa 1.1.1 (apple-ads-platform 1.109.0, Python {platform.python_version()})\n"
+        f"asa 1.1.2 (apple-ads-platform 1.109.0, Python {platform.python_version()})\n"
     )
 
 


### PR DESCRIPTION
## Summary

- bump the CLI contract from 1.1.1 to 1.1.2
- publish the current Apple Ads CLI repository branding and canonical URLs
- distribute organization-currency-safe legacy v5 campaign, ad group, keyword, lifetime-budget, and budget-order writes
- update release installation guidance and metadata assertions

## Validation

- 422 tests passed
- Ruff passed
- Platform manifest and generated skill references are current
- release metadata check passed for 1.1.2
- wheel and source distribution built successfully
- clean Python 3.12 wheel smoke test passed for version, help, config authentication, and safe get_me read

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for legacy v5 write operations that safely handle organization currency settings.
  - Updated repository branding across release materials.

- **Release**
  - Released CLI version 1.1.2.
  - Updated installation, validation, publishing, and version references for the 1.1.2 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->